### PR TITLE
fix broken deployment doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ Locally preview production build:
 npm run preview
 ```
 
-Checkout the [deployment documentation](https://v3.nuxtjs.org/docs/deployment) for more information.
+Checkout the [deployment documentation](https://nuxt.com/docs/getting-started/deployment) for more information.


### PR DESCRIPTION
i think this updated link is where we want to go?

https://nuxt.com/docs/getting-started/deployment